### PR TITLE
Mateusz Górny Assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ Also, value-objects are responsible for a little more than just plain data holdi
 * Integration tests with the real NBP API.
 * Replace Spring Framework with a different one.
 * The proposed architecture is not perfect. Suggest improvements.
+* Change SimpleCacheManager to different one

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This is an example project that calculates the amount balance to a given currenc
 * JDK 17
 * Gradle 7.4 (you can use the gradle wrapper instead)
 
+# REST API Documentation
+The REST API documentation is accessible after running the application on the `/swagger-ui/index.html` address
+
 # REST API
 ## Get account
 Endpoints:
@@ -78,4 +81,5 @@ Also, value-objects are responsible for a little more than just plain data holdi
 * Integration tests with the real NBP API.
 * Replace Spring Framework with a different one.
 * The proposed architecture is not perfect. Suggest improvements.
+
 * Change SimpleCacheManager to different one

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
     implementation 'io.github.openfeign:feign-httpclient:11.8'
     implementation 'io.github.openfeign:feign-jackson:11.8'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 
     // Use the latest Groovy version for Spock testing
     testImplementation 'org.codehaus.groovy:groovy:3.0.9'

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -11,6 +11,10 @@ import feign.jackson.JacksonEncoder;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheFactoryBean;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import pl.cleankod.exchange.core.domain.SingleValueObject;
@@ -27,10 +31,13 @@ import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
 import pl.cleankod.exchange.provider.nbp.errors.NbpErrorDecoder;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Currency;
+import java.util.List;
 
 @SpringBootConfiguration
 @EnableAutoConfiguration
+@EnableCaching
 public class ApplicationInitializer {
     public static void main(String[] args) {
         SpringApplication.run(ApplicationInitializer.class, args);
@@ -104,5 +111,21 @@ public class ApplicationInitializer {
             FindAccountUseCase findAccountUseCase
     ) {
         return new FindAccountService(findAccountAndConvertCurrencyUseCase, findAccountUseCase);
+    }
+
+    @Bean
+    public SimpleCacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        List<Cache> caches = new ArrayList<>();
+        caches.add(cacheBean().getObject());
+        cacheManager.setCaches(caches);
+        return cacheManager;
+    }
+
+    @Bean
+    public ConcurrentMapCacheFactoryBean cacheBean() {
+        ConcurrentMapCacheFactoryBean cacheFactoryBean = new ConcurrentMapCacheFactoryBean();
+        cacheFactoryBean.setName("currency-cache");
+        return cacheFactoryBean;
     }
 }

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -22,6 +22,7 @@ import pl.cleankod.exchange.entrypoint.AccountController;
 import pl.cleankod.exchange.entrypoint.ExceptionHandlerAdvice;
 import pl.cleankod.exchange.provider.AccountInMemoryRepository;
 import pl.cleankod.exchange.provider.CurrencyConversionNbpService;
+import pl.cleankod.exchange.provider.FindAccountService;
 import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
 
 import java.io.IOException;
@@ -70,11 +71,8 @@ public class ApplicationInitializer {
     }
 
     @Bean
-    AccountController accountController(
-            FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
-            FindAccountUseCase findAccountUseCase
-    ) {
-        return new AccountController(findAccountAndConvertCurrencyUseCase, findAccountUseCase);
+    AccountController accountController(FindAccountService findAccountService) {
+        return new AccountController(findAccountService);
     }
 
     @Bean
@@ -96,5 +94,13 @@ public class ApplicationInitializer {
             }
         });
         return module;
+    }
+
+    @Bean
+    public FindAccountService findAccountService(
+            FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
+            FindAccountUseCase findAccountUseCase
+    ) {
+        return new FindAccountService(findAccountAndConvertCurrencyUseCase, findAccountUseCase);
     }
 }

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -24,6 +24,7 @@ import pl.cleankod.exchange.provider.AccountInMemoryRepository;
 import pl.cleankod.exchange.provider.CurrencyConversionNbpService;
 import pl.cleankod.exchange.provider.FindAccountService;
 import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
+import pl.cleankod.exchange.provider.nbp.errors.NbpErrorDecoder;
 
 import java.io.IOException;
 import java.util.Currency;
@@ -47,6 +48,7 @@ public class ApplicationInitializer {
                 .client(new ApacheHttpClient())
                 .encoder(new JacksonEncoder())
                 .decoder(new JacksonDecoder())
+                .errorDecoder(new NbpErrorDecoder())
                 .target(ExchangeRatesNbpClient.class, nbpApiBaseUrl);
     }
 

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -1,5 +1,9 @@
 package pl.cleankod;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import feign.Feign;
 import feign.httpclient.ApacheHttpClient;
 import feign.jackson.JacksonDecoder;
@@ -9,6 +13,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
+import pl.cleankod.exchange.core.domain.SingleValueObject;
 import pl.cleankod.exchange.core.gateway.AccountRepository;
 import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
 import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
@@ -19,6 +24,7 @@ import pl.cleankod.exchange.provider.AccountInMemoryRepository;
 import pl.cleankod.exchange.provider.CurrencyConversionNbpService;
 import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
 
+import java.io.IOException;
 import java.util.Currency;
 
 @SpringBootConfiguration
@@ -64,13 +70,31 @@ public class ApplicationInitializer {
     }
 
     @Bean
-    AccountController accountController(FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
-                                        FindAccountUseCase findAccountUseCase) {
+    AccountController accountController(
+            FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
+            FindAccountUseCase findAccountUseCase
+    ) {
         return new AccountController(findAccountAndConvertCurrencyUseCase, findAccountUseCase);
     }
 
     @Bean
     ExceptionHandlerAdvice exceptionHandlerAdvice() {
         return new ExceptionHandlerAdvice();
+    }
+
+    @Bean
+    public SimpleModule singleValueObjectModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(SingleValueObject.class, new JsonSerializer<>() {
+            @Override
+            public void serialize(
+                    SingleValueObject singleValueObject,
+                    JsonGenerator jsonGenerator,
+                    SerializerProvider serializerProvider
+            ) throws IOException {
+                jsonGenerator.writeObject(singleValueObject.value());
+            }
+        });
+        return module;
     }
 }

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -1,9 +1,12 @@
 package pl.cleankod;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.Feign;
 import feign.httpclient.ApacheHttpClient;
 import feign.jackson.JacksonDecoder;
@@ -16,7 +19,10 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheFactoryBean;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
+import org.springframework.core.serializer.Deserializer;
+import pl.cleankod.exchange.core.domain.Account;
 import pl.cleankod.exchange.core.domain.SingleValueObject;
 import pl.cleankod.exchange.core.gateway.AccountRepository;
 import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
@@ -24,6 +30,7 @@ import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
 import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
 import pl.cleankod.exchange.entrypoint.AccountController;
 import pl.cleankod.exchange.entrypoint.ExceptionHandlerAdvice;
+import pl.cleankod.exchange.provider.AccountDeserializeService;
 import pl.cleankod.exchange.provider.AccountInMemoryRepository;
 import pl.cleankod.exchange.provider.CurrencyConversionNbpService;
 import pl.cleankod.exchange.provider.FindAccountService;
@@ -102,6 +109,7 @@ public class ApplicationInitializer {
                 jsonGenerator.writeObject(singleValueObject.value());
             }
         });
+        module.addDeserializer(Account.class, new AccountDeserializeService());
         return module;
     }
 

--- a/src/main/java/pl/cleankod/exchange/core/domain/Account.java
+++ b/src/main/java/pl/cleankod/exchange/core/domain/Account.java
@@ -1,13 +1,16 @@
 package pl.cleankod.exchange.core.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import pl.cleankod.exchange.provider.AccountDeserializeService;
 import pl.cleankod.util.Preconditions;
 
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+@JsonDeserialize(using = AccountDeserializeService.class)
 public record Account(Id id, Number number, Money balance) {
 
-    public static record Id(UUID value) {
+    public static record Id(UUID value) implements SingleValueObject<UUID> {
         public Id {
             Preconditions.requireNonNull(value);
         }
@@ -22,7 +25,7 @@ public record Account(Id id, Number number, Money balance) {
         }
     }
 
-    public static record Number(String value) {
+    public static record Number(String value) implements SingleValueObject<String> {
         private static final Pattern PATTERN =
                 Pattern.compile("\\d{2}[ ]?\\d{4}[ ]?\\d{4}[ ]?\\d{4}[ ]?\\d{4}[ ]?\\d{4}[ ]?\\d{4}");
 

--- a/src/main/java/pl/cleankod/exchange/core/domain/Account.java
+++ b/src/main/java/pl/cleankod/exchange/core/domain/Account.java
@@ -1,13 +1,10 @@
 package pl.cleankod.exchange.core.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import pl.cleankod.exchange.provider.AccountDeserializeService;
 import pl.cleankod.util.Preconditions;
 
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-@JsonDeserialize(using = AccountDeserializeService.class)
 public record Account(Id id, Number number, Money balance) {
 
     public static record Id(UUID value) implements SingleValueObject<UUID> {

--- a/src/main/java/pl/cleankod/exchange/core/domain/Money.java
+++ b/src/main/java/pl/cleankod/exchange/core/domain/Money.java
@@ -4,6 +4,7 @@ import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
 import pl.cleankod.util.Preconditions;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Currency;
 
 public record Money(BigDecimal amount, Currency currency) {
@@ -22,5 +23,13 @@ public record Money(BigDecimal amount, Currency currency) {
 
     public Money convert(CurrencyConversionService currencyConverter, Currency targetCurrency) {
         return currencyConverter.convert(this, targetCurrency);
+    }
+
+    public BigDecimal multiply(BigDecimal rate) {
+        return amount().multiply(rate).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    public BigDecimal divide(BigDecimal midRate) {
+        return amount().divide(midRate, 2, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/pl/cleankod/exchange/core/domain/SingleValueObject.java
+++ b/src/main/java/pl/cleankod/exchange/core/domain/SingleValueObject.java
@@ -1,0 +1,7 @@
+package pl.cleankod.exchange.core.domain;
+
+import java.io.Serializable;
+
+public interface SingleValueObject<T extends Serializable> {
+    T value();
+}

--- a/src/main/java/pl/cleankod/exchange/core/usecase/FindAccountAndConvertCurrencyUseCase.java
+++ b/src/main/java/pl/cleankod/exchange/core/usecase/FindAccountAndConvertCurrencyUseCase.java
@@ -24,12 +24,16 @@ public class FindAccountAndConvertCurrencyUseCase {
 
     public Optional<Account> execute(Account.Id id, Currency targetCurrency) {
         return accountRepository.find(id)
-                .map(account -> new Account(account.id(), account.number(), convert(account.balance(), targetCurrency)));
+                .map(account -> getConvertedAccount(account, targetCurrency));
     }
 
     public Optional<Account> execute(Account.Number number, Currency targetCurrency) {
         return accountRepository.find(number)
-                .map(account -> new Account(account.id(), account.number(), convert(account.balance(), targetCurrency)));
+                .map(account -> getConvertedAccount(account, targetCurrency));
+    }
+
+    private Account getConvertedAccount(Account account, Currency targetCurrency) {
+        return new Account(account.id(), account.number(), convert(account.balance(), targetCurrency));
     }
 
     private Money convert(Money money, Currency targetCurrency) {

--- a/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
@@ -1,5 +1,13 @@
 package pl.cleankod.exchange.entrypoint;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pl.cleankod.exchange.core.domain.Account;
@@ -10,6 +18,20 @@ import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequestMapping("/accounts")
+@OpenAPIDefinition(info = @Info(title = "Accounts API", version = "1.0", description = "API for accessing to the customer account"))
+@ApiResponses({
+        @ApiResponse(description = "Successfully returned account object", responseCode = "200"),
+        @ApiResponse(
+                description = "Client sent an invalid request",
+                responseCode = "400",
+                content = @Content(examples = @ExampleObject(value = "{\"message\":\"Client sent an invalid request\"}"))
+        ),
+        @ApiResponse(
+                description = "Server failed to fulfill a valid request due to an error with server",
+                responseCode = "500",
+                content = @Content(examples = @ExampleObject(value = "{\"message\":\"Server failed to fulfill a valid request due to an error with server\"}"))
+        )
+})
 public class AccountController {
 
     private final FindAccountService findAccountService;
@@ -19,6 +41,10 @@ public class AccountController {
     }
 
     @GetMapping(path = "/{id}")
+    @Parameters({
+            @Parameter(name = "id", description = "Account id"),
+            @Parameter(name = "currency", description = "Account currency")
+    })
     public ResponseEntity<Account> findAccountById(@PathVariable String id, @RequestParam(required = false) String currency) {
         return findAccountService.findAccountById(Account.Id.of(URLDecoder.decode(id, StandardCharsets.UTF_8)), currency)
                 .fold(
@@ -28,6 +54,10 @@ public class AccountController {
     }
 
     @GetMapping(path = "/number={number}")
+    @Parameters({
+            @Parameter(name = "number", description = "Account number"),
+            @Parameter(name = "currency", description = "Account currency")
+    })
     public ResponseEntity<Account> findAccountByNumber(@PathVariable String number, @RequestParam(required = false) String currency) {
         return findAccountService.findAccountByNumber(Account.Number.of(URLDecoder.decode(number, StandardCharsets.UTF_8)), currency)
                 .fold(

--- a/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
@@ -3,56 +3,33 @@ package pl.cleankod.exchange.entrypoint;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pl.cleankod.exchange.core.domain.Account;
-import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
-import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
+import pl.cleankod.exchange.provider.FindAccountService;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Currency;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/accounts")
 public class AccountController {
 
-    private final FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase;
-    private final FindAccountUseCase findAccountUseCase;
+    private final FindAccountService findAccountService;
 
-    public AccountController(FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
-                             FindAccountUseCase findAccountUseCase) {
-        this.findAccountAndConvertCurrencyUseCase = findAccountAndConvertCurrencyUseCase;
-        this.findAccountUseCase = findAccountUseCase;
+    public AccountController(FindAccountService findAccountService) {
+        this.findAccountService = findAccountService;
     }
 
     @GetMapping(path = "/{id}")
     public ResponseEntity<Account> findAccountById(@PathVariable String id, @RequestParam(required = false) String currency) {
-        return Optional.ofNullable(currency)
-                .map(s ->
-                        findAccountAndConvertCurrencyUseCase.execute(Account.Id.of(id), Currency.getInstance(s))
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build())
-                )
-                .orElseGet(() ->
-                        findAccountUseCase.execute(Account.Id.of(id))
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build())
-                );
+        return findAccountService.findAccountById(Account.Id.of(URLDecoder.decode(id, StandardCharsets.UTF_8)), currency)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping(path = "/number={number}")
     public ResponseEntity<Account> findAccountByNumber(@PathVariable String number, @RequestParam(required = false) String currency) {
-        Account.Number accountNumber = Account.Number.of(URLDecoder.decode(number, StandardCharsets.UTF_8));
-        return Optional.ofNullable(currency)
-                .map(s ->
-                        findAccountAndConvertCurrencyUseCase.execute(accountNumber, Currency.getInstance(s))
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build())
-                )
-                .orElseGet(() ->
-                        findAccountUseCase.execute(accountNumber)
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build())
-                );
+        return findAccountService.findAccountByNumber(Account.Number.of(URLDecoder.decode(number, StandardCharsets.UTF_8)), currency)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 
 

--- a/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
@@ -21,15 +21,19 @@ public class AccountController {
     @GetMapping(path = "/{id}")
     public ResponseEntity<Account> findAccountById(@PathVariable String id, @RequestParam(required = false) String currency) {
         return findAccountService.findAccountById(Account.Id.of(URLDecoder.decode(id, StandardCharsets.UTF_8)), currency)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .fold(
+                        ResponseEntity::ok,
+                        authenticationFailedReason -> ResponseEntity.notFound().build()
+                );
     }
 
     @GetMapping(path = "/number={number}")
     public ResponseEntity<Account> findAccountByNumber(@PathVariable String number, @RequestParam(required = false) String currency) {
         return findAccountService.findAccountByNumber(Account.Number.of(URLDecoder.decode(number, StandardCharsets.UTF_8)), currency)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .fold(
+                        ResponseEntity::ok,
+                        authenticationFailedReason -> ResponseEntity.notFound().build()
+                );
     }
 
 

--- a/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
@@ -13,9 +13,6 @@ import org.springframework.web.bind.annotation.*;
 import pl.cleankod.exchange.core.domain.Account;
 import pl.cleankod.exchange.provider.FindAccountService;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-
 @RestController
 @RequestMapping("/accounts")
 @OpenAPIDefinition(info = @Info(title = "Accounts API", version = "1.0", description = "API for accessing to the customer account"))
@@ -46,7 +43,7 @@ public class AccountController {
             @Parameter(name = "currency", description = "Account currency")
     })
     public ResponseEntity<Account> findAccountById(@PathVariable String id, @RequestParam(required = false) String currency) {
-        return findAccountService.findAccountById(Account.Id.of(URLDecoder.decode(id, StandardCharsets.UTF_8)), currency)
+        return findAccountService.findAccountById(id, currency)
                 .fold(
                         ResponseEntity::ok,
                         authenticationFailedReason -> ResponseEntity.notFound().build()
@@ -59,7 +56,7 @@ public class AccountController {
             @Parameter(name = "currency", description = "Account currency")
     })
     public ResponseEntity<Account> findAccountByNumber(@PathVariable String number, @RequestParam(required = false) String currency) {
-        return findAccountService.findAccountByNumber(Account.Number.of(URLDecoder.decode(number, StandardCharsets.UTF_8)), currency)
+        return findAccountService.findAccountByNumber(number, currency)
                 .fold(
                         ResponseEntity::ok,
                         authenticationFailedReason -> ResponseEntity.notFound().build()

--- a/src/main/java/pl/cleankod/exchange/entrypoint/ExceptionHandlerAdvice.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/ExceptionHandlerAdvice.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import pl.cleankod.exchange.core.usecase.CurrencyConversionException;
 import pl.cleankod.exchange.entrypoint.model.ApiError;
+import pl.cleankod.exchange.provider.nbp.errors.RestApiException;
 
 @ControllerAdvice
 public class ExceptionHandlerAdvice {
@@ -15,5 +16,10 @@ public class ExceptionHandlerAdvice {
     })
     protected ResponseEntity<ApiError> handleBadRequest(CurrencyConversionException ex) {
         return ResponseEntity.badRequest().body(new ApiError(ex.getMessage()));
+    }
+
+    @ExceptionHandler({RestApiException.class})
+    protected ResponseEntity<ApiError> handleRestApiException(RestApiException ex) {
+        return ResponseEntity.status(ex.getStatus()).body(new ApiError(ex.getMessage()));
     }
 }

--- a/src/main/java/pl/cleankod/exchange/provider/AccountDeserializeService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/AccountDeserializeService.java
@@ -1,0 +1,24 @@
+package pl.cleankod.exchange.provider;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import pl.cleankod.exchange.core.domain.Account;
+import pl.cleankod.exchange.core.domain.Money;
+
+import java.io.IOException;
+
+public class AccountDeserializeService extends JsonDeserializer<Account> {
+    @Override
+    public Account deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+        JsonNode jsonNode = jsonParser.getCodec().readTree(jsonParser);
+        JsonNode balanceNode = jsonNode.get("balance");
+
+        return new Account(
+                Account.Id.of(jsonNode.get("id").asText()),
+                Account.Number.of(jsonNode.get("number").asText()),
+                Money.of(balanceNode.get("amount").asText(), balanceNode.get("currency").asText())
+        );
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionNbpService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionNbpService.java
@@ -1,5 +1,6 @@
 package pl.cleankod.exchange.provider;
 
+import org.springframework.cache.annotation.Cacheable;
 import pl.cleankod.exchange.core.domain.Money;
 import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
 import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
@@ -17,6 +18,10 @@ public class CurrencyConversionNbpService implements CurrencyConversionService {
     }
 
     @Override
+    @Cacheable(
+            cacheNames = "currency-cache",
+            key = "#money.amount().toPlainString().concat('-').concat(#money.currency()).concat('-').concat(#targetCurrency)"
+    )
     public Money convert(Money money, Currency targetCurrency) {
         RateWrapper rateWrapper = exchangeRatesNbpClient.fetch("A", targetCurrency.getCurrencyCode());
         BigDecimal midRate = rateWrapper.rates().get(0).mid();

--- a/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionNbpService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionNbpService.java
@@ -20,7 +20,7 @@ public class CurrencyConversionNbpService implements CurrencyConversionService {
     public Money convert(Money money, Currency targetCurrency) {
         RateWrapper rateWrapper = exchangeRatesNbpClient.fetch("A", targetCurrency.getCurrencyCode());
         BigDecimal midRate = rateWrapper.rates().get(0).mid();
-        BigDecimal calculatedRate = money.amount().divide(midRate, RoundingMode.HALF_UP);
+        BigDecimal calculatedRate = money.amount().divide(midRate, 2, RoundingMode.HALF_UP);
         return new Money(calculatedRate, targetCurrency);
     }
 }

--- a/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionNbpService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionNbpService.java
@@ -6,8 +6,6 @@ import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
 import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
 import pl.cleankod.exchange.provider.nbp.model.RateWrapper;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Currency;
 
 public class CurrencyConversionNbpService implements CurrencyConversionService {
@@ -24,8 +22,9 @@ public class CurrencyConversionNbpService implements CurrencyConversionService {
     )
     public Money convert(Money money, Currency targetCurrency) {
         RateWrapper rateWrapper = exchangeRatesNbpClient.fetch("A", targetCurrency.getCurrencyCode());
-        BigDecimal midRate = rateWrapper.rates().get(0).mid();
-        BigDecimal calculatedRate = money.amount().divide(midRate, 2, RoundingMode.HALF_UP);
-        return new Money(calculatedRate, targetCurrency);
+        return new Money(
+                money.divide(rateWrapper.rates().get(0).mid()),
+                targetCurrency
+        );
     }
 }

--- a/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionStubService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionStubService.java
@@ -4,7 +4,6 @@ import pl.cleankod.exchange.core.domain.Money;
 import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Currency;
 
 public class CurrencyConversionStubService implements CurrencyConversionService {
@@ -20,6 +19,9 @@ public class CurrencyConversionStubService implements CurrencyConversionService 
 
     private Money calculate(Money money, Currency targetCurrency) {
         BigDecimal rate = "PLN".equals(targetCurrency.getCurrencyCode()) ? EUR_TO_PLN_RATE : PLN_TO_EUR_RATE;
-        return Money.of(money.amount().multiply(rate).setScale(2, RoundingMode.HALF_UP), targetCurrency);
+        return Money.of(
+                money.multiply(rate),
+                targetCurrency
+        );
     }
 }

--- a/src/main/java/pl/cleankod/exchange/provider/FindAccountService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/FindAccountService.java
@@ -7,6 +7,8 @@ import pl.cleankod.util.AccountFailedReason;
 import pl.cleankod.util.Preconditions;
 import pl.cleankod.util.Result;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Currency;
 import java.util.Optional;
 
@@ -22,8 +24,10 @@ public class FindAccountService {
         this.findAccountUseCase = findAccountUseCase;
     }
 
-    public Result<Account, AccountFailedReason> findAccountById(Account.Id accountId, String currency) {
-        Preconditions.requireNonNull(accountId);
+    public Result<Account, AccountFailedReason> findAccountById(String id, String currency) {
+        Preconditions.requireNonNull(id);
+
+        Account.Id accountId = Account.Id.of(URLDecoder.decode(id, StandardCharsets.UTF_8));
         return Optional.ofNullable(currency)
                 .map(s -> findAccountAndConvertCurrencyUseCase.execute(accountId, Currency.getInstance(s)))
                 .orElseGet(() -> findAccountUseCase.execute(accountId))
@@ -31,8 +35,10 @@ public class FindAccountService {
                 .orElseGet(() -> Result.fail(AccountFailedReason.NOT_FOUND));
     }
 
-    public Result<Account, AccountFailedReason> findAccountByNumber(Account.Number accountNumber, String currency) {
-        Preconditions.requireNonNull(accountNumber);
+    public Result<Account, AccountFailedReason> findAccountByNumber(String number, String currency) {
+        Preconditions.requireNonNull(number);
+
+        Account.Number accountNumber = Account.Number.of(URLDecoder.decode(number, StandardCharsets.UTF_8));
         return Optional.ofNullable(currency)
                 .map(s -> findAccountAndConvertCurrencyUseCase.execute(accountNumber, Currency.getInstance(s)))
                 .orElseGet(() -> findAccountUseCase.execute(accountNumber))

--- a/src/main/java/pl/cleankod/exchange/provider/FindAccountService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/FindAccountService.java
@@ -3,7 +3,9 @@ package pl.cleankod.exchange.provider;
 import pl.cleankod.exchange.core.domain.Account;
 import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
 import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
+import pl.cleankod.util.AccountFailedReason;
 import pl.cleankod.util.Preconditions;
+import pl.cleankod.util.Result;
 
 import java.util.Currency;
 import java.util.Optional;
@@ -20,17 +22,21 @@ public class FindAccountService {
         this.findAccountUseCase = findAccountUseCase;
     }
 
-    public Optional<Account> findAccountById(Account.Id accountId, String currency) {
+    public Result<Account, AccountFailedReason> findAccountById(Account.Id accountId, String currency) {
         Preconditions.requireNonNull(accountId);
         return Optional.ofNullable(currency)
                 .map(s -> findAccountAndConvertCurrencyUseCase.execute(accountId, Currency.getInstance(s)))
-                .orElseGet(() -> findAccountUseCase.execute(accountId));
+                .orElseGet(() -> findAccountUseCase.execute(accountId))
+                .map(Result::<Account, AccountFailedReason>successful)
+                .orElseGet(() -> Result.fail(AccountFailedReason.NOT_FOUND));
     }
 
-    public Optional<Account> findAccountByNumber(Account.Number accountNumber, String currency) {
+    public Result<Account, AccountFailedReason> findAccountByNumber(Account.Number accountNumber, String currency) {
         Preconditions.requireNonNull(accountNumber);
         return Optional.ofNullable(currency)
                 .map(s -> findAccountAndConvertCurrencyUseCase.execute(accountNumber, Currency.getInstance(s)))
-                .orElseGet(() -> findAccountUseCase.execute(accountNumber));
+                .orElseGet(() -> findAccountUseCase.execute(accountNumber))
+                .map(Result::<Account, AccountFailedReason>successful)
+                .orElseGet(() -> Result.fail(AccountFailedReason.NOT_FOUND));
     }
 }

--- a/src/main/java/pl/cleankod/exchange/provider/FindAccountService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/FindAccountService.java
@@ -1,0 +1,36 @@
+package pl.cleankod.exchange.provider;
+
+import pl.cleankod.exchange.core.domain.Account;
+import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
+import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
+import pl.cleankod.util.Preconditions;
+
+import java.util.Currency;
+import java.util.Optional;
+
+public class FindAccountService {
+    private final FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase;
+    private final FindAccountUseCase findAccountUseCase;
+
+    public FindAccountService(
+            FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
+            FindAccountUseCase findAccountUseCase
+    ) {
+        this.findAccountAndConvertCurrencyUseCase = findAccountAndConvertCurrencyUseCase;
+        this.findAccountUseCase = findAccountUseCase;
+    }
+
+    public Optional<Account> findAccountById(Account.Id accountId, String currency) {
+        Preconditions.requireNonNull(accountId);
+        return Optional.ofNullable(currency)
+                .map(s -> findAccountAndConvertCurrencyUseCase.execute(accountId, Currency.getInstance(s)))
+                .orElseGet(() -> findAccountUseCase.execute(accountId));
+    }
+
+    public Optional<Account> findAccountByNumber(Account.Number accountNumber, String currency) {
+        Preconditions.requireNonNull(accountNumber);
+        return Optional.ofNullable(currency)
+                .map(s -> findAccountAndConvertCurrencyUseCase.execute(accountNumber, Currency.getInstance(s)))
+                .orElseGet(() -> findAccountUseCase.execute(accountNumber));
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/provider/nbp/errors/NbpErrorDecoder.java
+++ b/src/main/java/pl/cleankod/exchange/provider/nbp/errors/NbpErrorDecoder.java
@@ -1,0 +1,16 @@
+package pl.cleankod.exchange.provider.nbp.errors;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class NbpErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        if (response.status() >= 400) {
+            return new RestApiException(response.status());
+        } else {
+            return new Exception("Generic exception");
+        }
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/provider/nbp/errors/RestApiException.java
+++ b/src/main/java/pl/cleankod/exchange/provider/nbp/errors/RestApiException.java
@@ -1,0 +1,26 @@
+package pl.cleankod.exchange.provider.nbp.errors;
+
+public class RestApiException extends Exception {
+    private final String message;
+    private final int status;
+    public RestApiException(int status) {
+        this.status = status;
+
+        if(status >= 500) {
+            this.message = "Server failed to fulfill a valid request due to an error with server";
+        } else if (status >= 400) {
+            this.message = "Client sent an invalid request";
+        } else {
+            this.message = "Unexpected internal server error";
+        }
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/pl/cleankod/util/AccountFailedReason.java
+++ b/src/main/java/pl/cleankod/util/AccountFailedReason.java
@@ -1,0 +1,5 @@
+package pl.cleankod.util;
+
+public enum AccountFailedReason {
+    NOT_FOUND
+}

--- a/src/main/java/pl/cleankod/util/Result.java
+++ b/src/main/java/pl/cleankod/util/Result.java
@@ -1,0 +1,89 @@
+package pl.cleankod.util;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class Result<S, F> {
+    private static final String FAIL_VALUE_CANNOT_BE_NULL = "The fail value cannot be null.";
+    private static final String SUCCESS_VALUE_CANNOT_BE_NULL = "The success value cannot be null.";
+    private final S successfulValue;
+    private final F failValue;
+    private final boolean successful;
+
+    public Result(S successfulValue, F failValue, boolean successful) {
+        this.successfulValue = successfulValue;
+        this.failValue = failValue;
+        this.successful = successful;
+    }
+
+    public static <S, F> Result<S, F> successful() {
+        return new Result<>(null, null, true);
+    }
+
+    public static <S, F> Result<S, F> successful(S value) {
+        return new Result<>(Objects.requireNonNull(value, SUCCESS_VALUE_CANNOT_BE_NULL), null, true);
+    }
+
+    public static <S, F> Result<S, F> fail() {
+        return new Result<>(null, null, false);
+    }
+
+    public static <S, F> Result<S, F> fail(F value) {
+        return new Result<>(null, Objects.requireNonNull(value, FAIL_VALUE_CANNOT_BE_NULL), false);
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public boolean isFail() {
+        return !successful;
+    }
+
+    public S successfulValue() {
+        return Objects.requireNonNull(successfulValue, SUCCESS_VALUE_CANNOT_BE_NULL);
+    }
+
+    public F failValue() {
+        return Objects.requireNonNull(failValue, FAIL_VALUE_CANNOT_BE_NULL);
+    }
+
+    public <X> Result<S, X> failMap(Function<F, X> failureMapper) {
+        if (isFail()) {
+            return Result.fail(failureMapper.apply(this.failValue));
+        }
+        return Optional.ofNullable(successfulValue)
+                .map(s -> new Result<S, X>(s, null, true))
+                .orElse(Result.successful());
+    }
+
+    public <Y> Result<Y, F> successMap(Function<S, Y> successMapper) {
+        if (isSuccessful()) {
+            return Result.successful(successMapper.apply(this.successfulValue));
+        }
+        return Result.fail(this.failValue);
+    }
+
+    public <U> U fold(Function<S, U> successMapper, Function<F, U> failureMapper) {
+        if (isFail()) {
+            return failureMapper.apply(this.failValue);
+        }
+        return successMapper.apply(this.successfulValue);
+    }
+
+    public <X, Y> Result<X, Y> biMap(Function<S, X> successMapper, Function<F, Y> failureMapper) {
+        if (isFail()) {
+            return Result.fail(failureMapper.apply(this.failValue));
+        }
+        return Result.successful(successMapper.apply(this.successfulValue));
+    }
+
+    public S orElseGet(Function<F, S> failureMapper) {
+        return Optional.ofNullable(this.successfulValue).orElseGet(() -> failureMapper.apply(this.failValue));
+    }
+
+    public S orElse(S other) {
+        return Optional.ofNullable(this.successfulValue).orElse(other);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 provider.nbp-api.base-url=http://api.nbp.pl/api
 app.base-currency=PLN
+feign.cache.enabled=true

--- a/src/test/groovy/pl/cleankod/BaseApplicationSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/BaseApplicationSpecification.groovy
@@ -1,12 +1,15 @@
 package pl.cleankod
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
 import org.apache.http.HttpResponse
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.methods.HttpUriRequest
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.util.EntityUtils
+import pl.cleankod.exchange.core.domain.Account
 import pl.cleankod.exchange.entrypoint.model.ApiError
+import pl.cleankod.exchange.provider.AccountDeserializeService
 import spock.lang.Specification
 
 abstract class BaseApplicationSpecification extends Specification {
@@ -17,6 +20,10 @@ abstract class BaseApplicationSpecification extends Specification {
   @SuppressWarnings('unused')
   def setupSpec() {
     if (init) {
+      SimpleModule module = new SimpleModule()
+      module.addDeserializer(Account.class, new AccountDeserializeService())
+      objectMapper.registerModule(module)
+
       ApplicationInitializer.main(new String[0])
       init = false
     }

--- a/src/test/groovy/pl/cleankod/exchange/AccountSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/AccountSpecification.groovy
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import org.apache.http.HttpResponse
+import org.apache.http.util.EntityUtils
 import pl.cleankod.BaseApplicationSpecification
 import pl.cleankod.exchange.core.domain.Account
 import pl.cleankod.exchange.core.domain.Money
@@ -111,5 +112,17 @@ class AccountSpecification extends BaseApplicationSpecification {
 
         then:
         response.getStatusLine().getStatusCode() == 404
+    }
+
+    def "should return an account without value"() {
+        given:
+        def accountNumberValue = "75 1240 2034 1111 0000 0306 8582"
+        def accountNumberUrlEncoded = URLEncoder.encode(accountNumberValue, StandardCharsets.UTF_8)
+
+        when:
+        def response = getResponse("/accounts/number=${accountNumberUrlEncoded}")
+
+        then:
+        EntityUtils.toString(response.getEntity(), "UTF-8") == "{\"id\":\"78743420-8ce9-11ec-b0d0-57b77255c208\",\"number\":\"75 1240 2034 1111 0000 0306 8582\",\"balance\":{\"amount\":456.78,\"currency\":\"EUR\"}}"
     }
 }

--- a/src/test/groovy/pl/cleankod/exchange/core/domain/AccountIdSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/core/domain/AccountIdSpecification.groovy
@@ -1,7 +1,6 @@
 package pl.cleankod.exchange.core.domain
 
 
-import pl.cleankod.exchange.core.domain.Account
 import spock.lang.Specification
 
 class AccountIdSpecification extends Specification {

--- a/src/test/groovy/pl/cleankod/exchange/core/domain/AccountNumberSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/core/domain/AccountNumberSpecification.groovy
@@ -1,6 +1,6 @@
 package pl.cleankod.exchange.core.domain
 
-import pl.cleankod.exchange.core.domain.Account
+
 import spock.lang.Specification
 
 class AccountNumberSpecification extends Specification {

--- a/src/test/groovy/pl/cleankod/exchange/core/domain/MoneySpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/core/domain/MoneySpecification.groovy
@@ -1,7 +1,6 @@
 package pl.cleankod.exchange.core.domain
 
 
-import pl.cleankod.exchange.core.domain.Money
 import spock.lang.Specification
 
 class MoneySpecification extends Specification {

--- a/src/test/groovy/pl/cleankod/exchange/provider/CurrencyConversionNbpServiceSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/provider/CurrencyConversionNbpServiceSpecification.groovy
@@ -1,0 +1,32 @@
+package pl.cleankod.exchange.provider
+
+import pl.cleankod.exchange.core.domain.Money
+import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient
+import pl.cleankod.exchange.provider.nbp.model.Rate
+import pl.cleankod.exchange.provider.nbp.model.RateWrapper
+import spock.lang.Specification
+
+class CurrencyConversionNbpServiceSpecification extends Specification {
+    def "should convert valid amount"() {
+        when:
+        ExchangeRatesNbpClient exchangeRatesNbpClient = Mock(ExchangeRatesNbpClient.class)
+        exchangeRatesNbpClient.fetch(_ as String, _ as String) >> {
+            return new RateWrapper("test", "USD", "USD", [new Rate(_ as String, _ as String, BigDecimal.valueOf(3))])
+        }
+
+        CurrencyConversionNbpService currencyConversionNbpService = new CurrencyConversionNbpService(
+                exchangeRatesNbpClient
+        )
+        Money money = currencyConversionNbpService.convert(Money.of(givenAmount, givenCurrency), Currency.getInstance("USD"))
+
+        then:
+        money != null
+        money.amount() == expectedAmount
+        money.currency() == expectedCurrency
+
+        where:
+        givenAmount                    | givenCurrency               || expectedAmount                 || expectedCurrency
+        "123.45"                       | "PLN"                       || BigDecimal.valueOf(41.15)     || Currency.getInstance("USD")
+        "12345678.9"                   | "EUR"                       || BigDecimal.valueOf(4115226.30) || Currency.getInstance("USD")
+    }
+}

--- a/src/test/groovy/pl/cleankod/exchange/provider/NbpServiceSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/provider/NbpServiceSpecification.groovy
@@ -7,7 +7,6 @@ import org.apache.http.util.EntityUtils
 import pl.cleankod.BaseApplicationSpecification
 
 class NbpServiceSpecification extends BaseApplicationSpecification {
-
     private static WireMockServer wireMockServer = new WireMockServer(
             WireMockConfiguration.options()
                     .port(8081)
@@ -16,7 +15,10 @@ class NbpServiceSpecification extends BaseApplicationSpecification {
     def setupSpec() {
         wireMockServer.start()
 
-        wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/EUR/2022-02-08").willReturn(WireMock.serverError()))
+        def body = "{\"table\":\"A\",\"currency\":\"euro\",\"code\":\"EUR\",\"rates\":[{\"no\":\"026/A/NBP/2022\",\"effectiveDate\":\"2022-02-08\",\"mid\":4.5452}]}"
+        wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/EUR/2022-02-08").willReturn(WireMock.ok(body)))
+
+        wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/SEK/2022-02-08").willReturn(WireMock.serverError()))
         wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/USD/2022-02-08").willReturn(WireMock.serviceUnavailable()))
         wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/JPY/2022-02-08").willReturn(WireMock.badRequest()))
         wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/GBP/2022-02-08").willReturn(WireMock.forbidden()))
@@ -36,9 +38,19 @@ class NbpServiceSpecification extends BaseApplicationSpecification {
 
         where:
         currency || statusCode || message
-        "EUR"    || 500        || "{\"message\":\"Server failed to fulfill a valid request due to an error with server\"}"
+        "SEK"    || 500        || "{\"message\":\"Server failed to fulfill a valid request due to an error with server\"}"
         "USD"    || 503        || "{\"message\":\"Server failed to fulfill a valid request due to an error with server\"}"
         "JPY"    || 400        || "{\"message\":\"Client sent an invalid request\"}"
         "GBP"    || 403        || "{\"message\":\"Client sent an invalid request\"}"
+    }
+
+    def "should return the same response after cache"() {
+        when:
+        def response1 = getResponse("/accounts/fa07c538-8ce4-11ec-9ad5-4f5a625cd744?currency=EUR")
+        def response2 = getResponse("/accounts/fa07c538-8ce4-11ec-9ad5-4f5a625cd744?currency=EUR")
+
+        then:
+        response1.getStatusLine().getStatusCode() == response2.getStatusLine().getStatusCode()
+        EntityUtils.toString(response1.getEntity(), "UTF-8") == EntityUtils.toString(response2.getEntity(), "UTF-8")
     }
 }

--- a/src/test/groovy/pl/cleankod/exchange/provider/NbpServiceSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/provider/NbpServiceSpecification.groovy
@@ -1,0 +1,44 @@
+package pl.cleankod.exchange.provider
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.apache.http.util.EntityUtils
+import pl.cleankod.BaseApplicationSpecification
+
+class NbpServiceSpecification extends BaseApplicationSpecification {
+
+    private static WireMockServer wireMockServer = new WireMockServer(
+            WireMockConfiguration.options()
+                    .port(8081)
+    )
+
+    def setupSpec() {
+        wireMockServer.start()
+
+        wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/EUR/2022-02-08").willReturn(WireMock.serverError()))
+        wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/USD/2022-02-08").willReturn(WireMock.serviceUnavailable()))
+        wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/JPY/2022-02-08").willReturn(WireMock.badRequest()))
+        wireMockServer.stubFor(WireMock.get("/exchangerates/rates/A/GBP/2022-02-08").willReturn(WireMock.forbidden()))
+    }
+
+    def cleanupSpec() {
+        wireMockServer.stop()
+    }
+
+    def "should throw an error"() {
+        when:
+        def response = getResponse("/accounts/fa07c538-8ce4-11ec-9ad5-4f5a625cd744?currency=${currency}")
+
+        then:
+        response.getStatusLine().statusCode == statusCode
+        EntityUtils.toString(response.getEntity(), "UTF-8") == message
+
+        where:
+        currency || statusCode || message
+        "EUR"    || 500        || "{\"message\":\"Server failed to fulfill a valid request due to an error with server\"}"
+        "USD"    || 503        || "{\"message\":\"Server failed to fulfill a valid request due to an error with server\"}"
+        "JPY"    || 400        || "{\"message\":\"Client sent an invalid request\"}"
+        "GBP"    || 403        || "{\"message\":\"Client sent an invalid request\"}"
+    }
+}


### PR DESCRIPTION
# Architecture improvements
- All beans should be moved to configuration class to cleaner ApplicationInitialization class
- For now the directory structure is one monolith. I'd rather break it down into separate modules.
- I'd rather remove `@EnableAutoConfiguration` and add all dependencies in one class. This allow to know exatly which modules is enabled. This allow also change some dependencies for testing.

# Coverage
<html>
<body>
<!--StartFragment--><div class="content" style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="breadCrumbs">Current scope: all classes</div><h1>Overall Coverage Summary</h1>

Package | Class, % | Method, % | Line, %
-- | -- | -- | --
all classes | 95,8% (23/24) | 83,7% (72/86) | 84,2% (154/183)

</div><div class="footer" style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div style="float: right;">generated on 2022-08-22 01:23</div></div><!--EndFragment-->
</body>
</html>Current scope: all classes
Overall Coverage Summary
Package	Class, %	Method, %	Line, %
all classes	95,8% (23/24)	83,7% (72/86)	84,2% (154/183)

Coverage Breakdown
[Package](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/index_SORT_BY_NAME_DESC.html)	[Class, %](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/index_SORT_BY_CLASS.html)	[Method, %](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/index_SORT_BY_METHOD.html)	[Line, %](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/index_SORT_BY_LINE.html)
[pl.cleankod](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-1/index.html)	100% (2/2)	100% (15/15)	100% (30/30)
[pl.cleankod.exchange.core.domain](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-2/index.html)	100% (4/4)	100% (14/14)	100% (24/24)
[pl.cleankod.exchange.core.usecase](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-3/index.html)	100% (3/3)	100% (9/9)	94,7% (18/19)
[pl.cleankod.exchange.entrypoint](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-4/index.html)	100% (2/2)	100% (8/8)	100% (11/11)
[pl.cleankod.exchange.entrypoint.model](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-5/index.html)	100% (1/1)	100% (1/1)	100% (1/1)
[pl.cleankod.exchange.provider](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-6/index.html)	80% (4/5)	71,4% (10/14)	84% (42/50)
[pl.cleankod.exchange.provider.nbp.errors](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-7/index.html)	100% (2/2)	100% (5/5)	84,6% (11/13)
[pl.cleankod.exchange.provider.nbp.model](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-8/index.html)	100% (2/2)	100% (2/2)	100% (2/2)
[pl.cleankod.util](http://localhost:63343/currency-rate-converter/docs/coverage/22.08.2022/ns-9/index.html)	100% (3/3)	44,4% (8/18)	45,5% (15/33)
generated on 2022-08-22 01:23


















