### PR TITLE
George Bejan's assessment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 
     // Apply the groovy plugin to also add support for Groovy (needed for Spock)
     id 'groovy'
+    id 'jacoco'
 }
 
 repositories {
@@ -33,4 +34,11 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+test {
+    finalizedBy jacocoTestReport // report is always generated after tests run
+}
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
     implementation 'io.github.openfeign:feign-httpclient:11.8'
     implementation 'io.github.openfeign:feign-jackson:11.8'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
 
     // Use the latest Groovy version for Spock testing
     testImplementation 'org.codehaus.groovy:groovy:3.0.9'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'io.github.openfeign:feign-httpclient:11.8'
     implementation 'io.github.openfeign:feign-jackson:11.8'
     implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+    implementation 'org.ehcache:ehcache:3.10.8'
 
     // Use the latest Groovy version for Spock testing
     testImplementation 'org.codehaus.groovy:groovy:3.0.9'

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import pl.cleankod.exchange.core.gateway.AccountRepository;
 import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
+import pl.cleankod.exchange.core.service.AccountService;
 import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
 import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
 import pl.cleankod.exchange.entrypoint.AccountController;
@@ -64,9 +65,14 @@ public class ApplicationInitializer {
     }
 
     @Bean
-    AccountController accountController(FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
-                                        FindAccountUseCase findAccountUseCase) {
-        return new AccountController(findAccountAndConvertCurrencyUseCase, findAccountUseCase);
+    AccountService accountService(FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
+                                  FindAccountUseCase findAccountUseCase) {
+        return new AccountService(findAccountAndConvertCurrencyUseCase, findAccountUseCase);
+    }
+
+    @Bean
+    AccountController accountController(AccountService accountService) {
+        return new AccountController(accountService);
     }
 
     @Bean

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -1,84 +1,17 @@
 package pl.cleankod;
 
-import feign.Feign;
-import feign.httpclient.ApacheHttpClient;
-import feign.jackson.JacksonDecoder;
-import feign.jackson.JacksonEncoder;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.env.Environment;
-import pl.cleankod.exchange.core.gateway.AccountRepository;
-import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
-import pl.cleankod.exchange.core.service.AccountService;
-import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
-import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
-import pl.cleankod.exchange.entrypoint.AccountController;
-import pl.cleankod.exchange.entrypoint.ExceptionHandlerAdvice;
-import pl.cleankod.exchange.provider.AccountInMemoryRepository;
-import pl.cleankod.exchange.provider.CurrencyConversionNbpService;
-import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
-import pl.cleankod.exchange.provider.nbp.NbpClientErrorDecoder;
-
-import java.util.Currency;
+import org.springframework.context.annotation.Import;
+import pl.cleankod.exchange.config.ApplicationConfig;
+import pl.cleankod.exchange.config.CacheConfig;
 
 @SpringBootConfiguration
 @EnableAutoConfiguration
+@Import({ApplicationConfig.class, CacheConfig.class})
 public class ApplicationInitializer {
     public static void main(String[] args) {
         SpringApplication.run(ApplicationInitializer.class, args);
-    }
-
-    @Bean
-    AccountRepository accountRepository() {
-        return new AccountInMemoryRepository();
-    }
-
-    @Bean
-    ExchangeRatesNbpClient exchangeRatesNbpClient(Environment environment) {
-        String nbpApiBaseUrl = environment.getRequiredProperty("provider.nbp-api.base-url");
-        return Feign.builder()
-                .client(new ApacheHttpClient())
-                .encoder(new JacksonEncoder())
-                .decoder(new JacksonDecoder())
-                .errorDecoder(new NbpClientErrorDecoder())
-                .target(ExchangeRatesNbpClient.class, nbpApiBaseUrl);
-    }
-
-    @Bean
-    CurrencyConversionService currencyConversionService(ExchangeRatesNbpClient exchangeRatesNbpClient) {
-        return new CurrencyConversionNbpService(exchangeRatesNbpClient);
-    }
-
-    @Bean
-    FindAccountUseCase findAccountUseCase(AccountRepository accountRepository) {
-        return new FindAccountUseCase(accountRepository);
-    }
-
-    @Bean
-    FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase(
-            AccountRepository accountRepository,
-            CurrencyConversionService currencyConversionService,
-            Environment environment
-    ) {
-        Currency baseCurrency = Currency.getInstance(environment.getRequiredProperty("app.base-currency"));
-        return new FindAccountAndConvertCurrencyUseCase(accountRepository, currencyConversionService, baseCurrency);
-    }
-
-    @Bean
-    AccountService accountService(FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
-                                  FindAccountUseCase findAccountUseCase) {
-        return new AccountService(findAccountAndConvertCurrencyUseCase, findAccountUseCase);
-    }
-
-    @Bean
-    AccountController accountController(AccountService accountService) {
-        return new AccountController(accountService);
-    }
-
-    @Bean
-    ExceptionHandlerAdvice exceptionHandlerAdvice() {
-        return new ExceptionHandlerAdvice();
     }
 }

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -19,6 +19,7 @@ import pl.cleankod.exchange.entrypoint.ExceptionHandlerAdvice;
 import pl.cleankod.exchange.provider.AccountInMemoryRepository;
 import pl.cleankod.exchange.provider.CurrencyConversionNbpService;
 import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
+import pl.cleankod.exchange.provider.nbp.NbpClientErrorDecoder;
 
 import java.util.Currency;
 
@@ -41,6 +42,7 @@ public class ApplicationInitializer {
                 .client(new ApacheHttpClient())
                 .encoder(new JacksonEncoder())
                 .decoder(new JacksonDecoder())
+                .errorDecoder(new NbpClientErrorDecoder())
                 .target(ExchangeRatesNbpClient.class, nbpApiBaseUrl);
     }
 

--- a/src/main/java/pl/cleankod/exchange/config/ApplicationConfig.java
+++ b/src/main/java/pl/cleankod/exchange/config/ApplicationConfig.java
@@ -1,0 +1,84 @@
+package pl.cleankod.exchange.config;
+
+import feign.Feign;
+import feign.httpclient.ApacheHttpClient;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import org.ehcache.Cache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import pl.cleankod.exchange.core.gateway.AccountRepository;
+import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
+import pl.cleankod.exchange.core.service.AccountService;
+import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
+import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
+import pl.cleankod.exchange.entrypoint.AccountController;
+import pl.cleankod.exchange.entrypoint.ExceptionHandlerAdvice;
+import pl.cleankod.exchange.provider.AccountInMemoryRepository;
+import pl.cleankod.exchange.provider.CurrencyConversionNbpService;
+import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpCachedClient;
+import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
+import pl.cleankod.exchange.provider.nbp.NbpClientErrorDecoder;
+import pl.cleankod.exchange.provider.nbp.model.RateWrapper;
+
+import java.util.Currency;
+
+@Configuration
+public class ApplicationConfig {
+
+    @Bean
+    AccountRepository accountRepository() {
+        return new AccountInMemoryRepository();
+    }
+
+    @Bean
+    ExchangeRatesNbpClient exchangeRatesNbpClient(Environment environment,
+                                                  Cache<String, RateWrapper> exchangeRateCache) {
+        String nbpApiBaseUrl = environment.getRequiredProperty("provider.nbp-api.base-url");
+        ExchangeRatesNbpClient exchangeRatesNbpFeignClient = Feign.builder()
+                .client(new ApacheHttpClient())
+                .encoder(new JacksonEncoder())
+                .decoder(new JacksonDecoder())
+                .errorDecoder(new NbpClientErrorDecoder())
+                .target(ExchangeRatesNbpClient.class, nbpApiBaseUrl);
+
+        return new ExchangeRatesNbpCachedClient(exchangeRatesNbpFeignClient, exchangeRateCache);
+    }
+
+    @Bean
+    CurrencyConversionService currencyConversionService(ExchangeRatesNbpClient exchangeRatesNbpClient) {
+        return new CurrencyConversionNbpService(exchangeRatesNbpClient);
+    }
+
+    @Bean
+    FindAccountUseCase findAccountUseCase(AccountRepository accountRepository) {
+        return new FindAccountUseCase(accountRepository);
+    }
+
+    @Bean
+    FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase(
+            AccountRepository accountRepository,
+            CurrencyConversionService currencyConversionService,
+            Environment environment
+    ) {
+        Currency baseCurrency = Currency.getInstance(environment.getRequiredProperty("app.base-currency"));
+        return new FindAccountAndConvertCurrencyUseCase(accountRepository, currencyConversionService, baseCurrency);
+    }
+
+    @Bean
+    AccountService accountService(FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
+                                  FindAccountUseCase findAccountUseCase) {
+        return new AccountService(findAccountAndConvertCurrencyUseCase, findAccountUseCase);
+    }
+
+    @Bean
+    AccountController accountController(AccountService accountService) {
+        return new AccountController(accountService);
+    }
+
+    @Bean
+    ExceptionHandlerAdvice exceptionHandlerAdvice() {
+        return new ExceptionHandlerAdvice();
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/config/CacheConfig.java
+++ b/src/main/java/pl/cleankod/exchange/config/CacheConfig.java
@@ -1,0 +1,38 @@
+package pl.cleankod.exchange.config;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import pl.cleankod.exchange.provider.nbp.model.RateWrapper;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+@Configuration
+public class CacheConfig {
+
+    public static final String EXCHANGE_RATE_CACHE_NAME = "exchangeRates";
+
+    @Bean
+    public CacheManager cacheManager() {
+        CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build();
+        cacheManager.init();
+        return cacheManager;
+    }
+
+    @Bean
+    public Cache<String, RateWrapper> exchangeRateCache(CacheManager cacheManager) {
+        CacheConfiguration<String, RateWrapper> cacheConfiguration = CacheConfigurationBuilder
+                .newCacheConfigurationBuilder(String.class, RateWrapper.class, ResourcePoolsBuilder.heap(100))
+                .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.of(1, ChronoUnit.HOURS)))
+                .build();
+
+        return cacheManager.createCache(EXCHANGE_RATE_CACHE_NAME, cacheConfiguration);
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/core/domain/ApplicationError.java
+++ b/src/main/java/pl/cleankod/exchange/core/domain/ApplicationError.java
@@ -1,0 +1,20 @@
+package pl.cleankod.exchange.core.domain;
+
+public class ApplicationError {
+
+    private final String message;
+    private final int httpStatus;
+
+    public ApplicationError(String message, int httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/core/domain/Money.java
+++ b/src/main/java/pl/cleankod/exchange/core/domain/Money.java
@@ -4,6 +4,7 @@ import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
 import pl.cleankod.util.Preconditions;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Currency;
 
 public record Money(BigDecimal amount, Currency currency) {
@@ -22,5 +23,10 @@ public record Money(BigDecimal amount, Currency currency) {
 
     public Money convert(CurrencyConversionService currencyConverter, Currency targetCurrency) {
         return currencyConverter.convert(this, targetCurrency);
+    }
+
+    public Money convert(BigDecimal conversionRate, Currency targetCurrency) {
+        BigDecimal convertedAmount = amount.divide(conversionRate, targetCurrency.getDefaultFractionDigits(), RoundingMode.HALF_EVEN);
+        return Money.of(convertedAmount, targetCurrency);
     }
 }

--- a/src/main/java/pl/cleankod/exchange/core/service/AccountService.java
+++ b/src/main/java/pl/cleankod/exchange/core/service/AccountService.java
@@ -1,9 +1,11 @@
 package pl.cleankod.exchange.core.service;
 
 import pl.cleankod.exchange.core.domain.Account;
+import pl.cleankod.exchange.core.domain.ApplicationError;
 import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
 import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
 import pl.cleankod.util.Preconditions;
+import pl.cleankod.util.domain.Result;
 
 import java.util.Currency;
 import java.util.Optional;
@@ -19,7 +21,7 @@ public class AccountService {
         this.findAccountUseCase = findAccountUseCase;
     }
 
-    public Optional<Account> find(Account.Id accountId, Currency currency) {
+    public Result<Account, ApplicationError> find(Account.Id accountId, Currency currency) {
         Preconditions.requireNonNull(accountId);
 
         return Optional.ofNullable(currency)
@@ -27,7 +29,7 @@ public class AccountService {
                 .orElseGet(() -> findAccountUseCase.execute(accountId));
     }
 
-    public Optional<Account> find(Account.Number accountNumber, Currency currency) {
+    public Result<Account, ApplicationError> find(Account.Number accountNumber, Currency currency) {
         Preconditions.requireNonNull(accountNumber);
 
         return Optional.ofNullable(currency)

--- a/src/main/java/pl/cleankod/exchange/core/service/AccountService.java
+++ b/src/main/java/pl/cleankod/exchange/core/service/AccountService.java
@@ -1,0 +1,37 @@
+package pl.cleankod.exchange.core.service;
+
+import pl.cleankod.exchange.core.domain.Account;
+import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
+import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
+import pl.cleankod.util.Preconditions;
+
+import java.util.Currency;
+import java.util.Optional;
+
+public class AccountService {
+
+    private final FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase;
+    private final FindAccountUseCase findAccountUseCase;
+
+    public AccountService(FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
+                          FindAccountUseCase findAccountUseCase) {
+        this.findAccountAndConvertCurrencyUseCase = findAccountAndConvertCurrencyUseCase;
+        this.findAccountUseCase = findAccountUseCase;
+    }
+
+    public Optional<Account> find(Account.Id accountId, Currency currency) {
+        Preconditions.requireNonNull(accountId);
+
+        return Optional.ofNullable(currency)
+                .map(c -> findAccountAndConvertCurrencyUseCase.execute(accountId, c))
+                .orElseGet(() -> findAccountUseCase.execute(accountId));
+    }
+
+    public Optional<Account> find(Account.Number accountNumber, Currency currency) {
+        Preconditions.requireNonNull(accountNumber);
+
+        return Optional.ofNullable(currency)
+                .map(c -> findAccountAndConvertCurrencyUseCase.execute(accountNumber, c))
+                .orElseGet(() -> findAccountUseCase.execute(accountNumber));
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/core/usecase/AccountNotFoundError.java
+++ b/src/main/java/pl/cleankod/exchange/core/usecase/AccountNotFoundError.java
@@ -1,0 +1,19 @@
+package pl.cleankod.exchange.core.usecase;
+
+import pl.cleankod.exchange.core.domain.Account;
+import pl.cleankod.exchange.core.domain.ApplicationError;
+
+public class AccountNotFoundError extends ApplicationError {
+
+    public AccountNotFoundError(Account.Id id) {
+        this(String.format("The account with id %s was not found.", id.value()));
+    }
+
+    public AccountNotFoundError(Account.Number number) {
+        this(String.format("The account with number %s was not found.", number.value()));
+    }
+
+    private AccountNotFoundError(String message) {
+        super(message, 404);
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/core/usecase/CurrencyConversionError.java
+++ b/src/main/java/pl/cleankod/exchange/core/usecase/CurrencyConversionError.java
@@ -1,0 +1,12 @@
+package pl.cleankod.exchange.core.usecase;
+
+import pl.cleankod.exchange.core.domain.ApplicationError;
+
+import java.util.Currency;
+
+public class CurrencyConversionError extends ApplicationError {
+
+    public CurrencyConversionError(Currency sourceCurrency, Currency targetCurrency) {
+        super(String.format("Cannot convert currency from %s to %s.", sourceCurrency, targetCurrency), 400);
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/core/usecase/CurrencyConversionException.java
+++ b/src/main/java/pl/cleankod/exchange/core/usecase/CurrencyConversionException.java
@@ -1,9 +1,0 @@
-package pl.cleankod.exchange.core.usecase;
-
-import java.util.Currency;
-
-public class CurrencyConversionException extends IllegalStateException {
-    public CurrencyConversionException(Currency sourceCurrency, Currency targetCurrency) {
-        super(String.format("Cannot convert currency from %s to %s.", sourceCurrency, targetCurrency));
-    }
-}

--- a/src/main/java/pl/cleankod/exchange/core/usecase/FindAccountAndConvertCurrencyUseCase.java
+++ b/src/main/java/pl/cleankod/exchange/core/usecase/FindAccountAndConvertCurrencyUseCase.java
@@ -1,12 +1,13 @@
 package pl.cleankod.exchange.core.usecase;
 
 import pl.cleankod.exchange.core.domain.Account;
+import pl.cleankod.exchange.core.domain.ApplicationError;
 import pl.cleankod.exchange.core.domain.Money;
 import pl.cleankod.exchange.core.gateway.AccountRepository;
 import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
+import pl.cleankod.util.domain.Result;
 
 import java.util.Currency;
-import java.util.Optional;
 
 public class FindAccountAndConvertCurrencyUseCase {
 
@@ -22,25 +23,32 @@ public class FindAccountAndConvertCurrencyUseCase {
         this.baseCurrency = baseCurrency;
     }
 
-    public Optional<Account> execute(Account.Id id, Currency targetCurrency) {
+    public Result<Account, ApplicationError> execute(Account.Id id, Currency targetCurrency) {
         return accountRepository.find(id)
-                .map(account -> new Account(account.id(), account.number(), convert(account.balance(), targetCurrency)));
+                .map(account -> convert(account, targetCurrency))
+                .orElse(Result.fail(new AccountNotFoundError(id)));
     }
 
-    public Optional<Account> execute(Account.Number number, Currency targetCurrency) {
+    public Result<Account, ApplicationError> execute(Account.Number number, Currency targetCurrency) {
         return accountRepository.find(number)
-                .map(account -> new Account(account.id(), account.number(), convert(account.balance(), targetCurrency)));
+                .map(account -> convert(account, targetCurrency))
+                .orElse(Result.fail(new AccountNotFoundError(number)));
     }
 
-    private Money convert(Money money, Currency targetCurrency) {
+    private Result<Account, ApplicationError> convert(Account account, Currency targetCurrency) {
+        return convert(account.balance(), targetCurrency)
+                .successMap(convertedBalance -> new Account(account.id(), account.number(), convertedBalance));
+    }
+
+    private Result<Money, ApplicationError> convert(Money money, Currency targetCurrency) {
         if (!baseCurrency.equals(targetCurrency)) {
-            return money.convert(currencyConversionService, targetCurrency);
+            return Result.successful(money.convert(currencyConversionService, targetCurrency));
         }
 
         if (!money.currency().equals(targetCurrency)) {
-            throw new CurrencyConversionException(money.currency(), targetCurrency);
+            return Result.fail(new CurrencyConversionError(money.currency(), targetCurrency));
         }
 
-        return money;
+        return Result.successful(money);
     }
 }

--- a/src/main/java/pl/cleankod/exchange/core/usecase/FindAccountUseCase.java
+++ b/src/main/java/pl/cleankod/exchange/core/usecase/FindAccountUseCase.java
@@ -1,9 +1,9 @@
 package pl.cleankod.exchange.core.usecase;
 
 import pl.cleankod.exchange.core.domain.Account;
+import pl.cleankod.exchange.core.domain.ApplicationError;
 import pl.cleankod.exchange.core.gateway.AccountRepository;
-
-import java.util.Optional;
+import pl.cleankod.util.domain.Result;
 
 public class FindAccountUseCase {
     private final AccountRepository accountRepository;
@@ -12,11 +12,15 @@ public class FindAccountUseCase {
         this.accountRepository = accountRepository;
     }
 
-    public Optional<Account> execute(Account.Id id) {
-        return accountRepository.find(id);
+    public Result<Account, ApplicationError> execute(Account.Id id) {
+        return accountRepository.find(id)
+                .map(Result::<Account, ApplicationError>successful)
+                .orElse(Result.fail(new AccountNotFoundError(id)));
     }
 
-    public Optional<Account> execute(Account.Number number) {
-        return accountRepository.find(number);
+    public Result<Account, ApplicationError> execute(Account.Number number) {
+        return accountRepository.find(number)
+                .map(Result::<Account, ApplicationError>successful)
+                .orElse(Result.fail(new AccountNotFoundError(number)));
     }
 }

--- a/src/main/java/pl/cleankod/exchange/entrypoint/AccountApi.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/AccountApi.java
@@ -1,0 +1,36 @@
+package pl.cleankod.exchange.entrypoint;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import pl.cleankod.exchange.core.domain.Account;
+import pl.cleankod.exchange.entrypoint.model.ApiError;
+
+@Tag(name = "Account", description = "Account API")
+public interface AccountApi {
+
+    @Operation(summary = "Find an account by id")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = Account.class))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ApiError.class))),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
+    @GetMapping(path = "/{id}")
+    ResponseEntity<?> findAccountById(@PathVariable String id, @RequestParam(required = false) String currency);
+
+    @Operation(summary = "Find an account by number")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = Account.class))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ApiError.class))),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
+    @GetMapping(path = "/number={number}")
+    ResponseEntity<?> findAccountByNumber(@PathVariable String number, @RequestParam(required = false) String currency);
+}

--- a/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/AccountController.java
@@ -3,8 +3,7 @@ package pl.cleankod.exchange.entrypoint;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pl.cleankod.exchange.core.domain.Account;
-import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
-import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
+import pl.cleankod.exchange.core.service.AccountService;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -15,45 +14,29 @@ import java.util.Optional;
 @RequestMapping("/accounts")
 public class AccountController {
 
-    private final FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase;
-    private final FindAccountUseCase findAccountUseCase;
+    private final AccountService accountService;
 
-    public AccountController(FindAccountAndConvertCurrencyUseCase findAccountAndConvertCurrencyUseCase,
-                             FindAccountUseCase findAccountUseCase) {
-        this.findAccountAndConvertCurrencyUseCase = findAccountAndConvertCurrencyUseCase;
-        this.findAccountUseCase = findAccountUseCase;
+    public AccountController(AccountService accountService) {
+        this.accountService = accountService;
     }
 
     @GetMapping(path = "/{id}")
     public ResponseEntity<Account> findAccountById(@PathVariable String id, @RequestParam(required = false) String currency) {
-        return Optional.ofNullable(currency)
-                .map(s ->
-                        findAccountAndConvertCurrencyUseCase.execute(Account.Id.of(id), Currency.getInstance(s))
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build())
-                )
-                .orElseGet(() ->
-                        findAccountUseCase.execute(Account.Id.of(id))
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build())
-                );
+        Account.Id accountId = Account.Id.of(id);
+        Currency requestedCurrency = Optional.ofNullable(currency)
+                .map(s -> Currency.getInstance(currency))
+                .orElse(null);
+
+        return ResponseEntity.of(accountService.find(accountId, requestedCurrency));
     }
 
     @GetMapping(path = "/number={number}")
     public ResponseEntity<Account> findAccountByNumber(@PathVariable String number, @RequestParam(required = false) String currency) {
         Account.Number accountNumber = Account.Number.of(URLDecoder.decode(number, StandardCharsets.UTF_8));
-        return Optional.ofNullable(currency)
-                .map(s ->
-                        findAccountAndConvertCurrencyUseCase.execute(accountNumber, Currency.getInstance(s))
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build())
-                )
-                .orElseGet(() ->
-                        findAccountUseCase.execute(accountNumber)
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build())
-                );
+        Currency requestedCurrency = Optional.ofNullable(currency)
+                .map(s -> Currency.getInstance(currency))
+                .orElse(null);
+
+        return ResponseEntity.of(accountService.find(accountNumber, requestedCurrency));
     }
-
-
 }

--- a/src/main/java/pl/cleankod/exchange/entrypoint/ExceptionHandlerAdvice.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/ExceptionHandlerAdvice.java
@@ -4,14 +4,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import pl.cleankod.exchange.entrypoint.model.ApiError;
+import pl.cleankod.exchange.provider.nbp.exception.NbpClientException;
 
 @ControllerAdvice
 public class ExceptionHandlerAdvice {
 
-    @ExceptionHandler({
-            IllegalArgumentException.class
-    })
+    @ExceptionHandler(IllegalArgumentException.class)
     protected ResponseEntity<ApiError> handleBadRequest(IllegalArgumentException ex) {
         return ResponseEntity.badRequest().body(new ApiError(ex.getMessage()));
+    }
+
+    @ExceptionHandler(NbpClientException.class)
+    protected ResponseEntity<ApiError> handleNbpClientException(NbpClientException ex) {
+        return ResponseEntity.internalServerError().body(new ApiError(ex.getMessage()));
     }
 }

--- a/src/main/java/pl/cleankod/exchange/entrypoint/ExceptionHandlerAdvice.java
+++ b/src/main/java/pl/cleankod/exchange/entrypoint/ExceptionHandlerAdvice.java
@@ -3,17 +3,15 @@ package pl.cleankod.exchange.entrypoint;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import pl.cleankod.exchange.core.usecase.CurrencyConversionException;
 import pl.cleankod.exchange.entrypoint.model.ApiError;
 
 @ControllerAdvice
 public class ExceptionHandlerAdvice {
 
     @ExceptionHandler({
-            CurrencyConversionException.class,
             IllegalArgumentException.class
     })
-    protected ResponseEntity<ApiError> handleBadRequest(CurrencyConversionException ex) {
+    protected ResponseEntity<ApiError> handleBadRequest(IllegalArgumentException ex) {
         return ResponseEntity.badRequest().body(new ApiError(ex.getMessage()));
     }
 }

--- a/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionNbpService.java
+++ b/src/main/java/pl/cleankod/exchange/provider/CurrencyConversionNbpService.java
@@ -6,7 +6,6 @@ import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
 import pl.cleankod.exchange.provider.nbp.model.RateWrapper;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Currency;
 
 public class CurrencyConversionNbpService implements CurrencyConversionService {
@@ -20,7 +19,6 @@ public class CurrencyConversionNbpService implements CurrencyConversionService {
     public Money convert(Money money, Currency targetCurrency) {
         RateWrapper rateWrapper = exchangeRatesNbpClient.fetch("A", targetCurrency.getCurrencyCode());
         BigDecimal midRate = rateWrapper.rates().get(0).mid();
-        BigDecimal calculatedRate = money.amount().divide(midRate, RoundingMode.HALF_UP);
-        return new Money(calculatedRate, targetCurrency);
+        return money.convert(midRate, targetCurrency);
     }
 }

--- a/src/main/java/pl/cleankod/exchange/provider/nbp/ExchangeRatesNbpCachedClient.java
+++ b/src/main/java/pl/cleankod/exchange/provider/nbp/ExchangeRatesNbpCachedClient.java
@@ -1,0 +1,28 @@
+package pl.cleankod.exchange.provider.nbp;
+
+import org.ehcache.Cache;
+import pl.cleankod.exchange.provider.nbp.model.RateWrapper;
+
+import java.util.Optional;
+
+public class ExchangeRatesNbpCachedClient implements ExchangeRatesNbpClient {
+
+    private final ExchangeRatesNbpClient exchangeRatesNbpClient;
+    private final Cache<String, RateWrapper> cache;
+
+    public ExchangeRatesNbpCachedClient(ExchangeRatesNbpClient exchangeRatesNbpClient,
+                                        Cache<String, RateWrapper> cache) {
+        this.exchangeRatesNbpClient = exchangeRatesNbpClient;
+        this.cache = cache;
+    }
+
+    @Override
+    public RateWrapper fetch(String table, String currency) {
+        return Optional.ofNullable(cache.get(currency))
+                .orElseGet(() -> {
+                    RateWrapper exchangeRate = exchangeRatesNbpClient.fetch(table, currency);
+                    cache.put(currency, exchangeRate);
+                    return exchangeRate;
+                });
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/provider/nbp/NbpClientErrorDecoder.java
+++ b/src/main/java/pl/cleankod/exchange/provider/nbp/NbpClientErrorDecoder.java
@@ -1,0 +1,18 @@
+package pl.cleankod.exchange.provider.nbp;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import pl.cleankod.exchange.provider.nbp.exception.NbpClientException;
+
+public class NbpClientErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        return switch (response.status()) {
+            case 400 -> new NbpClientException("Bad request to the NBP API.");
+            case 404 -> new NbpClientException("NBP API cannot be found.");
+            case 503 -> new NbpClientException("NBP API is unavailable.");
+            default -> new NbpClientException("NBP API request failed.");
+        };
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/provider/nbp/exception/NbpClientException.java
+++ b/src/main/java/pl/cleankod/exchange/provider/nbp/exception/NbpClientException.java
@@ -1,0 +1,8 @@
+package pl.cleankod.exchange.provider.nbp.exception;
+
+public class NbpClientException extends RuntimeException {
+
+    public NbpClientException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/pl/cleankod/util/ErrorTransformer.java
+++ b/src/main/java/pl/cleankod/util/ErrorTransformer.java
@@ -1,0 +1,16 @@
+package pl.cleankod.util;
+
+import org.springframework.http.ResponseEntity;
+import pl.cleankod.exchange.core.domain.ApplicationError;
+import pl.cleankod.exchange.entrypoint.model.ApiError;
+
+public final class ErrorTransformer {
+
+    private ErrorTransformer() {}
+
+    public static ResponseEntity<ApiError> toApiError(ApplicationError applicationError) {
+        return ResponseEntity
+                .status(applicationError.getHttpStatus())
+                .body(new ApiError(applicationError.getMessage()));
+    }
+}

--- a/src/main/java/pl/cleankod/util/domain/Currencies.java
+++ b/src/main/java/pl/cleankod/util/domain/Currencies.java
@@ -1,0 +1,16 @@
+package pl.cleankod.util.domain;
+
+import java.util.Currency;
+import java.util.Optional;
+
+public final class Currencies {
+
+    private Currencies() {
+    }
+
+    public static Currency getOrNull(String currency) {
+        return Optional.ofNullable(currency)
+                .map(s -> Currency.getInstance(currency))
+                .orElse(null);
+    }
+}

--- a/src/main/java/pl/cleankod/util/domain/Result.java
+++ b/src/main/java/pl/cleankod/util/domain/Result.java
@@ -1,0 +1,90 @@
+package pl.cleankod.util.domain;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class Result<S, F> {
+
+    private static final String FAIL_VALUE_CANNOT_BE_NULL = "The fail value cannot be null.";
+    private static final String SUCCESS_VALUE_CANNOT_BE_NULL = "The success value cannot be null.";
+    private final S successfulValue;
+    private final F failValue;
+    private final boolean successful;
+
+    private Result(S successfulValue, F failValue, boolean successful) {
+        this.successfulValue = successfulValue;
+        this.failValue = failValue;
+        this.successful = successful;
+    }
+
+    public static <S, F> Result<S, F> successful() {
+        return new Result<>(null, null, true);
+    }
+
+    public static <S, F> Result<S, F> successful(S value) {
+        return new Result<>(Objects.requireNonNull(value, SUCCESS_VALUE_CANNOT_BE_NULL), null, true);
+    }
+
+    public static <S, F> Result<S, F> fail() {
+        return new Result<>(null, null, false);
+    }
+
+    public static <S, F> Result<S, F> fail(F value) {
+        return new Result<>(null, Objects.requireNonNull(value, FAIL_VALUE_CANNOT_BE_NULL), false);
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public boolean isFail() {
+        return !successful;
+    }
+
+    public S successfulValue() {
+        return Objects.requireNonNull(successfulValue, SUCCESS_VALUE_CANNOT_BE_NULL);
+    }
+
+    public F failValue() {
+        return Objects.requireNonNull(failValue, FAIL_VALUE_CANNOT_BE_NULL);
+    }
+
+    public <X> Result<S, X> failMap(Function<F, X> failureMapper) {
+        if (isFail()) {
+            return Result.fail(failureMapper.apply(this.failValue));
+        }
+        return Optional.ofNullable(successfulValue)
+                .map(s -> new Result<S, X>(s, null, true))
+                .orElse(Result.successful());
+    }
+
+    public <Y> Result<Y, F> successMap(Function<S, Y> successMapper) {
+        if (isSuccessful()) {
+            return Result.successful(successMapper.apply(this.successfulValue));
+        }
+        return Result.fail(this.failValue);
+    }
+
+    public <U> U fold(Function<S, U> successMapper, Function<F, U> failureMapper) {
+        if (isFail()) {
+            return failureMapper.apply(this.failValue);
+        }
+        return successMapper.apply(this.successfulValue);
+    }
+
+    public <X, Y> Result<X, Y> biMap(Function<S, X> successMapper, Function<F, Y> failureMapper) {
+        if (isFail()) {
+            return Result.fail(failureMapper.apply(this.failValue));
+        }
+        return Result.successful(successMapper.apply(this.successfulValue));
+    }
+
+    public S orElseGet(Function<F, S> failureMapper) {
+        return Optional.ofNullable(this.successfulValue).orElseGet(() -> failureMapper.apply(this.failValue));
+    }
+
+    public S orElse(S other) {
+        return Optional.ofNullable(this.successfulValue).orElse(other);
+    }
+}

--- a/src/test/groovy/pl/cleankod/exchange/AccountSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/AccountSpecification.groovy
@@ -100,16 +100,19 @@ class AccountSpecification extends BaseApplicationSpecification {
 
         then:
         response.getStatusLine().getStatusCode() == 404
+        transformError(response).message() == "The account with id ${accountId} was not found."
     }
 
     def "should not find an account by number"() {
         given:
-        def accountNumber = URLEncoder.encode("11 1750 0009 0000 0000 2156 6004", StandardCharsets.UTF_8)
+        def accountNumber = "11 1750 0009 0000 0000 2156 6004"
+        def accountNumberUrlEncoded = URLEncoder.encode(accountNumber, StandardCharsets.UTF_8)
 
         when:
-        def response = getResponse("/accounts/number=${accountNumber}")
+        def response = getResponse("/accounts/number=${accountNumberUrlEncoded}")
 
         then:
         response.getStatusLine().getStatusCode() == 404
+        transformError(response).message() == "The account with number ${accountNumber} was not found."
     }
 }

--- a/src/test/groovy/pl/cleankod/exchange/core/domain/MoneySpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/core/domain/MoneySpecification.groovy
@@ -57,4 +57,27 @@ class MoneySpecification extends Specification {
         where:
         givenAmount << ["EUR", "\0", "123,45"]
     }
+
+    def "should convert the amount correctly based on conversion rate"() {
+        when:
+        Money converted = money.convert(conversionRate, targetCurrency)
+
+        then:
+        converted != null
+        converted.amount().scale() == targetCurrency.getDefaultFractionDigits()
+        converted.amount() == expectedAmount
+
+        where:
+        money                     | conversionRate | targetCurrency              || expectedAmount
+        Money.of("0", "PLN")      | 4.5287         | Currency.getInstance("EUR") || 0
+        Money.of("0.1", "PLN")    | 4.5287         | Currency.getInstance("EUR") || 0.02
+        Money.of("1.23", "PLN")   | 4.5287         | Currency.getInstance("EUR") || 0.27
+        Money.of("10", "PLN")     | 4.5287         | Currency.getInstance("EUR") || 2.21
+        Money.of("123.45", "PLN") | 4.5287         | Currency.getInstance("EUR") || 27.26
+
+        Money.of("0", "EUR")      | 0.2207         | Currency.getInstance("PLN") || 0
+        Money.of("10", "EUR")     | 0.2207         | Currency.getInstance("PLN") || 45.31
+        Money.of("100", "EUR")    | 0.2207         | Currency.getInstance("PLN") || 453.10
+        Money.of("123.45", "EUR") | 0.2207         | Currency.getInstance("PLN") || 559.36
+    }
 }

--- a/src/test/groovy/pl/cleankod/exchange/provider/NbpClientSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/provider/NbpClientSpecification.groovy
@@ -1,0 +1,82 @@
+package pl.cleankod.exchange.provider
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import pl.cleankod.BaseApplicationSpecification
+
+class NbpClientSpecification extends BaseApplicationSpecification {
+
+    private static WireMockServer wireMockServer = new WireMockServer(
+            WireMockConfiguration.options()
+                    .port(8081)
+    )
+
+    def setupSpec() {
+        wireMockServer.start()
+
+        def body = "{\"table\":\"A\",\"currency\":\"euro\",\"code\":\"EUR\",\"rates\":[{\"no\":\"026/A/NBP/2022\",\"effectiveDate\":\"2022-02-08\",\"mid\":4.5452}]}"
+        wireMockServer.stubFor(
+                WireMock.get("/exchangerates/rates/A/EUR/2022-02-08")
+                        .willReturn(WireMock.ok(body))
+        )
+    }
+
+    def cleanupSpec() {
+        wireMockServer.stop()
+    }
+
+    def "should return error message when the call to NBP API is not made correctly"() {
+        given:
+        wireMockServer.stubFor(
+                WireMock.get("/exchangerates/rates/A/EUR/2022-02-08")
+                        .willReturn(WireMock.badRequest())
+        )
+
+        def accountId = "fa07c538-8ce4-11ec-9ad5-4f5a625cd744"
+        def currency = "EUR"
+
+        when:
+        def response = getResponse("/accounts/${accountId}?currency=${currency}")
+
+        then:
+        response.getStatusLine().getStatusCode() == 500
+        transformError(response).message() == "Bad request to the NBP API."
+    }
+
+    def "should return error message when the NBP API is not not found"() {
+        given:
+        wireMockServer.stubFor(
+                WireMock.get("/exchangerates/rates/A/EUR/2022-02-08")
+                        .willReturn(WireMock.notFound())
+        )
+
+        def accountId = "fa07c538-8ce4-11ec-9ad5-4f5a625cd744"
+        def currency = "EUR"
+
+        when:
+        def response = getResponse("/accounts/${accountId}?currency=${currency}")
+
+        then:
+        response.getStatusLine().getStatusCode() == 500
+        transformError(response).message() == "NBP API cannot be found."
+    }
+
+    def "should return error message when the NBP API is not available"() {
+        given:
+        wireMockServer.stubFor(
+                WireMock.get("/exchangerates/rates/A/EUR/2022-02-08")
+                        .willReturn(WireMock.serviceUnavailable())
+        )
+
+        def accountId = "fa07c538-8ce4-11ec-9ad5-4f5a625cd744"
+        def currency = "EUR"
+
+        when:
+        def response = getResponse("/accounts/${accountId}?currency=${currency}")
+
+        then:
+        response.getStatusLine().getStatusCode() == 500
+        transformError(response).message() == "NBP API is unavailable."
+    }
+}

--- a/src/test/groovy/pl/cleankod/exchange/provider/NbpClientSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/provider/NbpClientSpecification.groovy
@@ -4,6 +4,11 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import pl.cleankod.BaseApplicationSpecification
+import pl.cleankod.exchange.core.domain.Account
+
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET
+import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern
 
 class NbpClientSpecification extends BaseApplicationSpecification {
 
@@ -78,5 +83,20 @@ class NbpClientSpecification extends BaseApplicationSpecification {
         then:
         response.getStatusLine().getStatusCode() == 500
         transformError(response).message() == "NBP API is unavailable."
+    }
+
+    def "should not make NBP API call if the exchange rate is cached"() {
+        given:
+        def accountId = "fa07c538-8ce4-11ec-9ad5-4f5a625cd744"
+        def currency = "EUR"
+
+        when:
+        get("/accounts/${accountId}?currency=${currency}", Account)
+        get("/accounts/${accountId}?currency=${currency}", Account)
+        get("/accounts/${accountId}?currency=${currency}", Account)
+        get("/accounts/${accountId}?currency=${currency}", Account)
+
+        then:
+        wireMockServer.verify(1, newRequestPattern(GET, urlPathEqualTo("/exchangerates/rates/A/EUR/2022-02-08")))
     }
 }


### PR DESCRIPTION
# Completed tasks

### Move parameter-specific logic outside the controller

* added the `AccountService` to handle the logic of calling the usecases

### Test coverage report
* used jacoco - https://docs.gradle.org/current/userguide/jacoco_plugin.html
* the report is generated each time the tests are ran

### Auto generating REST API docs
* used springdoc - https://springdoc.org
* docs available at `<base_url>/swagger-ui/index.html`

### Rounding when calculating the amount is not done correctly for this type of operation and it is done in the wrong place
* the conversion service was responsible for
  * calling the `NBP Client` to get the exchange rate 
  * converting the amount
* updated the `Money` model to handle conversion based on an exchange rate
  * this way we can unit test the mathematical operations
  * the conversion service does not have multiple responsibilities anymore
* used the `HALF_EVEN` rounding mode because this is the rounding mode that statistically minimizes cumulative error when applied repeatedly over a sequence of calculations

### Replace exceptions with Result which improves the overall methods API readability and forces error handling
* replaced `CurrencyConversionException` flow with `Result`
  * the failure from `Result` is handled in the controller, but here I had the problem that could no longer make the controller method return an `Account`
    * now the response type can be either `Account` or `ApiError`
    * I made the controller method return `ResponseEntity<?>` which breaks the swagger generation, so I extracted the controller definition to `AccountApi` (and added the extra information needed by swagger here)
    * an alternative solution here could be to throw an exception from controller on `Result` failure and let the controller advice catch that 
* `ApplicationError` contains the `httpStatus` that will be returned 
  * an alternative solution here is to have a mapper from `ApplicationError` to a http status based on type at the controller level. This way the core module errors don't need to know about what http status is returned in case of error

### Better error handling, especially of potential errors from NBP API
* added error decoder to the feign client which adds a proper error message based on NBP API error status code

### Caching the NBP API results
* used ehcache
* created a new implementation of the `ExchangeRatesNbpClient` which caches the response and returns the response from cache if present
  * the `nbp feign client` does not know about any caching
  * the `nbp client` can be used with or without the caching simply by updating the config 
* moved the bean config to separate files to improve readability 
